### PR TITLE
Default git branch shouldn't have to be called master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <github.global.server>github</github.global.server>
         <jsch.agentproxy.version>0.0.9</jsch.agentproxy.version>
         <jetty.version>9.4.30.v20200611</jetty.version> <!-- Should be same as murp version's -->
-        <jgit.version>5.8.1.202007141445-r</jgit.version>
+        <jgit.version>5.10.0.202012080955-r</jgit.version>
     </properties>
 
     <prerequisites>
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.7</version>
+            <version>2.8.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/com/danielflower/apprunner/App.java
+++ b/src/main/java/com/danielflower/apprunner/App.java
@@ -30,7 +30,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static com.danielflower.apprunner.FileSandbox.fullPath;
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
 
 public class App {
     public static final Logger log = LoggerFactory.getLogger(App.class);
@@ -61,7 +60,7 @@ public class App {
 
         log.info("Detecting providers...");
         AppRunnerFactoryProvider runnerProvider = AppRunnerFactoryProvider.create(config);
-        log.info("Registered providers..." + LINE_SEPARATOR + runnerProvider.describeRunners());
+        log.info("Registered providers..." + System.lineSeparator() + runnerProvider.describeRunners());
 
         estate = new AppEstate(
             proxyMap,
@@ -147,7 +146,7 @@ public class App {
                     try {
                         estate.update(a.name(), new OutputToWriterBridge(writer));
                     } catch (Exception e) {
-                        log.warn("Error while starting up " + a.name() + LINE_SEPARATOR + "Logs:" + LINE_SEPARATOR + writer, e);
+                        log.warn("Error while starting up " + a.name() + System.lineSeparator() + "Logs:" + System.lineSeparator() + writer, e);
                     }
                 }
             }));

--- a/src/main/java/com/danielflower/apprunner/io/OutputToWriterBridge.java
+++ b/src/main/java/com/danielflower/apprunner/io/OutputToWriterBridge.java
@@ -7,8 +7,6 @@ import org.slf4j.LoggerFactory;
 import java.io.InterruptedIOException;
 import java.io.Writer;
 
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
-
 public class OutputToWriterBridge implements InvocationOutputHandler, LineConsumer {
     public static final Logger log = LoggerFactory.getLogger(OutputToWriterBridge.class);
     private final Writer writer;
@@ -19,7 +17,7 @@ public class OutputToWriterBridge implements InvocationOutputHandler, LineConsum
 
     public void consumeLine(String line) {
         try {
-            writer.write(line + LINE_SEPARATOR);
+            writer.write(line + System.lineSeparator());
             writer.flush();
         } catch (InterruptedIOException iox) {
             Thread.currentThread().interrupt();

--- a/src/main/java/com/danielflower/apprunner/runners/AppRunnerFactoryProvider.java
+++ b/src/main/java/com/danielflower/apprunner/runners/AppRunnerFactoryProvider.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 import java.util.concurrent.*;
 
 import static java.util.stream.Collectors.joining;
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
 
 public class AppRunnerFactoryProvider {
     public static final Logger log = LoggerFactory.getLogger(AppRunnerFactoryProvider.class);
@@ -58,7 +57,7 @@ public class AppRunnerFactoryProvider {
     public String describeRunners() {
         return factories.stream()
                 .map(AppRunnerFactory::versionInfo)
-                .collect(joining(LINE_SEPARATOR));
+                .collect(joining(System.lineSeparator()));
     }
 
     public List<AppRunnerFactory> factories() {

--- a/src/main/java/com/danielflower/apprunner/runners/ProcessStarter.java
+++ b/src/main/java/com/danielflower/apprunner/runners/ProcessStarter.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
 import static com.danielflower.apprunner.FileSandbox.fullPath;
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
 
 public class ProcessStarter {
     public static final Logger log = LoggerFactory.getLogger(ProcessStarter.class);
@@ -83,7 +82,7 @@ public class ProcessStarter {
 
     public static Pair<Boolean, String> run(CommandLine command) {
         ExecuteWatchdog watchDog = new ExecuteWatchdog(30000);
-        StringBuffer output = new StringBuffer();
+        StringBuilder output = new StringBuilder();
         Executor executor = createExecutor(output::append, command, new File("."), watchDog);
         output.setLength(0);
         try {
@@ -111,7 +110,7 @@ public class ProcessStarter {
         executor.setWorkingDirectory(projectRoot);
         executor.setWatchdog(watchDog);
         executor.setStreamHandler(new PumpStreamHandler(new WriterOutputStream(new WriterToOutputBridge(consoleLogHandler))));
-        consoleLogHandler.consumeLine(fullPath(executor.getWorkingDirectory()) + "> " + String.join(" ", command.toStrings()) + LINE_SEPARATOR);
+        consoleLogHandler.consumeLine(fullPath(executor.getWorkingDirectory()) + "> " + String.join(" ", command.toStrings()) + System.lineSeparator());
         return executor;
     }
 

--- a/src/main/java/com/danielflower/apprunner/runners/PythonRunnerFactory.java
+++ b/src/main/java/com/danielflower/apprunner/runners/PythonRunnerFactory.java
@@ -2,7 +2,6 @@ package com.danielflower.apprunner.runners;
 
 import com.danielflower.apprunner.Config;
 import org.apache.commons.exec.CommandLine;
-import org.apache.commons.lang3.SystemUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/danielflower/apprunner/web/v1/AppResource.java
+++ b/src/main/java/com/danielflower/apprunner/web/v1/AppResource.java
@@ -30,7 +30,6 @@ import java.util.*;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
-import static org.apache.commons.io.IOUtils.LINE_SEPARATOR;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 @Description(value = "Application")
@@ -216,16 +215,9 @@ public class AppResource {
     }
 
     private static String getContributorsList(AppDescription app) {
-        String contributors = "";
         String[] contributorsArray = app.contributors().toArray(new String[0]);
         Arrays.sort(contributorsArray);
-        for (String name : contributorsArray) {
-            contributors += name + ", ";
-        }
-        if (contributors.length() > 2) {
-            contributors = contributors.substring(0, contributors.length() - 2);
-        }
-        return contributors;
+        return String.join(", ", contributorsArray);
     }
 
     private static URI appUrl(AppDescription app, URI restURI, String path) {
@@ -393,13 +385,13 @@ public class AppResource {
 
         public void write(OutputStream output) throws IOException, WebApplicationException {
             try (Writer writer = new OutputStreamWriter(output)) {
-                writer.write("Going to build and deploy " + name + " at " + new Date() + LINE_SEPARATOR);
+                writer.write("Going to build and deploy " + name + " at " + new Date() + System.lineSeparator());
                 writer.flush();
                 log.info("Going to update " + name);
                 try {
                     estate.update(name, new OutputToWriterBridge(writer));
                     log.info("Finished updating " + name);
-                    writer.write("Success" + LINE_SEPARATOR);
+                    writer.write("Success" + System.lineSeparator());
                 } catch (URISyntaxException uex) {
                     throw new ClientErrorException("Invalid GIT URL", 400);
                 } catch (AppNotFoundException e) {

--- a/src/test/java/com/danielflower/apprunner/mgmt/AppManagerTest.java
+++ b/src/test/java/com/danielflower/apprunner/mgmt/AppManagerTest.java
@@ -1,16 +1,12 @@
 package com.danielflower.apprunner.mgmt;
 
+import java.io.IOException;
+
 import com.danielflower.apprunner.FileSandbox;
 import com.danielflower.apprunner.web.WebServerTest;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.InitCommand;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.junit.Test;
 import scaffolding.AppRepo;
-import scaffolding.Photocopier;
-
-import java.io.File;
-import java.io.IOException;
 
 public class AppManagerTest {
 


### PR DESCRIPTION
Just checkout the HEAD object id.
Update commons-io to fix delete on Windows and replace uses of deprecated LINE_SEPARATOR